### PR TITLE
Issue #1: Add Japanese README and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # React + TypeScript + Vite
 
+日本語版: [README_ja.md](README_ja.md)
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,5 +1,7 @@
 # React + TypeScript + Vite
 
+英語版: [README.md](README.md)
+
 このテンプレートは、ViteでReactをHMRといくつかのESLintルールとともに動作させるための最小セットアップを提供します。
 
 日本語版: このファイル (README_ja.md)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,43 @@
+# React + TypeScript + Vite
+
+このテンプレートは、ViteでReactをHMRといくつかのESLintルールとともに動作させるための最小セットアップを提供します。
+
+日本語版: このファイル (README_ja.md)
+
+## Reactコンパイラ
+
+このテンプレートでは、開発とビルドのパフォーマンスへの影響のためReact Compilerは有効になっていません。有効化するには次のドキュメントを参照してください: https://react.dev/learn/react-compiler/installation
+
+## ESLint設定の拡張
+
+本番アプリケーションを開発している場合は、型認識のあるルールを有効にするよう設定を更新することをお勧めします。
+
+```js
+export default defineConfig([
+  globalIgnores(['dist']),
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [
+      // Other configs...
+
+      // Remove tseslint.configs.recommended and replace with this
+      tseslint.configs.recommendedTypeChecked,
+      // Alternatively, use this for stricter rules
+      tseslint.configs.strictTypeChecked,
+      // Optionally, add this for stylistic rules
+      tseslint.configs.stylisticTypeChecked,
+
+      // Other configs...
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.node.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // other options...
+    },
+  },
+])
+```
+
+英語版: [README.md](README.md)


### PR DESCRIPTION
This PR addresses Issue #1 by adding a Japanese README (README_ja.md) and ensuring both README.md and README_ja.md include links to each other so users can switch languages.

Changes:
- Added README_ja.md (Japanese translation)
- Updated README.md to include a link to README_ja.md

This matches the requested repo structure: README.md (English) and README_ja.md (Japanese) with mutual links.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1765432016144 -->